### PR TITLE
add Java native & static method support and update model with Pydantic

### DIFF
--- a/capa/features/extractors/frida/extractor.py
+++ b/capa/features/extractors/frida/extractor.py
@@ -12,6 +12,7 @@ from capa.features.common import (
     ARCH_AARCH64,
     ARCH_AMD64,
     ARCH_I386,
+    ARCH_ARM,
     FORMAT_APK
 )
 from capa.features.insn import API, Number

--- a/capa/features/extractors/frida/models.py
+++ b/capa/features/extractors/frida/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 import json
 

--- a/scripts/frida/frida_api_models.py
+++ b/scripts/frida/frida_api_models.py
@@ -1,0 +1,67 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field, ConfigDict, model_validator
+import json
+from pathlib import Path
+
+
+class JavaApi(BaseModel):
+    package: str
+    class_name: str = Field(alias="class")
+    method: Optional[str] = None  # null only for constructors
+    arguments: bool = True  # Whether to capture and log method arguments
+    static: bool = False
+    native: bool = False
+    ctor: bool = False
+
+    # Pydantic config, allowing using alias to visit field
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode='after')
+    def validate_java_api_field_consistency(self):
+        if self.ctor:
+            if self.method is not None:
+                raise ValueError('Constructors must have "method" field as null.')
+            if self.static:
+                raise ValueError('Constructors must have "static" field as False.')
+            if self.native:
+                raise ValueError('Constructors must have "native" field as False.')
+        else:
+            if self.method is None:
+                raise ValueError('Methods (ctor=false) "method" field cannot be null.')
+           
+        return self
+
+
+class JniApi(BaseModel):
+    pass
+
+
+class NativeApi(BaseModel):
+    pass
+
+
+class JavaSection(BaseModel):
+    methods: List[JavaApi] = Field(default_factory=list)
+
+
+class JniSection(BaseModel):
+    methods: List[JniApi] = Field(default_factory=list)
+
+
+class NativeSection(BaseModel):
+    methods: List[NativeApi] = Field(default_factory=list)
+
+
+class FridaApiSpec(BaseModel):
+    """Main configuration for Frida APIs"""
+    java: Optional[JavaSection] = None
+    jni: Optional[JniSection] = None
+    native: Optional[NativeSection] = None
+    
+    @classmethod
+    def from_json_file(cls, json_path: Path) -> "FridaApiSpec":
+        """Load and validate API configuration from JSON file"""
+        with open(json_path, 'r') as f:
+            data = json.load(f)
+        return cls(**data)
+

--- a/scripts/frida/hook_templates/java_constructor.template
+++ b/scripts/frida/hook_templates/java_constructor.template
@@ -3,13 +3,14 @@ try {
     {{VAR_NAME}}.$init.overloads.forEach(function(overload) {
         overload.implementation = function() {
             var args = [];
+            {% if capture_args %}
             for (var i = 0; i < arguments.length; i++) {
                 args.push({
                     name: 'arg' + i, 
                     value: processValue(arguments[i])
                 });
             }
-            
+            {% endif %}
             recordApiCall('{{CLASS_NAME}}.<init>', args);
             return this.$init.apply(this, arguments);
         };

--- a/scripts/frida/hook_templates/java_method.template
+++ b/scripts/frida/hook_templates/java_method.template
@@ -3,18 +3,23 @@ try {
     {{VAR_NAME}}.{{METHOD_NAME}}.overloads.forEach(function(overload) {
         overload.implementation = function() {
             var args = [];
+            {% if capture_args %}
             for (var i = 0; i < arguments.length; i++) {
                 args.push({
                     name: 'arg' + i, 
                     value: processValue(arguments[i])
                 });
             }
-            
+            {% endif %}
+            {% if is_static %}
+            var result = {{VAR_NAME}}.{{METHOD_NAME}}.apply({{VAR_NAME}}, arguments);
+            {% else %}
             var result = this.{{METHOD_NAME}}.apply(this, arguments);
+            {% endif %}
             recordApiCall('{{CLASS_NAME}}.{{METHOD_NAME}}', args);
             return result;
         };
     });
 } catch (e) {
-    console.log('[ERROR] Failed to hook {{CLASS_NAME}}.{{METHOD_NAME}}: ' + e.message);
+    console.log('[ERROR] Failed to hook Java {% if is_static %}static {% elif is_native %}native {% endif %}method {{CLASS_NAME}}.{{METHOD_NAME}}: ' + e.message);
 }


### PR DESCRIPTION
Done:
1. Java native & static method support. Can hook those two apis.
2. Using Jinja2 for conditional argument handling. It can reduce template complexity. 
    Single java_method.template file can handle static/instance/native methods now.
3. Pydantic API validation in frida_api_models.py.
4. Current API Format:
```json
{
    "java": {
        "methods": [
            {
                "package": "java.io",
                "class": "File", 
                "method": null,
                "arguments": true,
                "static": false,
                "native": false,
                "ctor": true
            },
        ]
    },
}
```