### PR TITLE
Add native API hooking support

### DIFF
--- a/capa/features/extractors/frida/extractor.py
+++ b/capa/features/extractors/frida/extractor.py
@@ -145,7 +145,7 @@ class FridaExtractor(DynamicFeatureExtractor):
         return "".join(parts)
     
     @classmethod
-    def from_json_file(cls, json_path: Path) -> "FridaExtractor":
-        """Entry point: Create an extractor from a JSON file""" 
-        report = FridaReport.from_json_file(json_path)
+    def from_jsonl_file(cls, jsonl_path: Path) -> "FridaExtractor":
+        """Entry point: Create an extractor from a JSONL file""" 
+        report = FridaReport.from_jsonl_file(jsonl_path)
         return cls(report)

--- a/capa/features/extractors/frida/models.py
+++ b/capa/features/extractors/frida/models.py
@@ -49,12 +49,12 @@ class FridaReport(FlexibleModel):
     processes: List[Process] = Field(default_factory=list)
     
     @classmethod
-    def from_json_file(cls, json_path) -> "FridaReport":
-        """Load from JSON Lines file created by log_converter.py"""
+    def from_jsonl_file(cls, jsonl_path) -> "FridaReport":
+        """Load from JSON Lines file"""
         metadata = None
         api_calls = []
 
-        with open(json_path, 'r') as f:
+        with open(jsonl_path, 'r') as f:
             content = f.read()
             for line in content.splitlines():
                 record = json.loads(line)
@@ -63,6 +63,9 @@ class FridaReport(FlexibleModel):
                     metadata = Metadata(**record["metadata"])
                 elif "api" in record and "java_api" in record["api"]:
                     call = Call(**record["api"]["java_api"])
+                    api_calls.append(call)
+                elif "api" in record and "native_api" in record["api"]:
+                    call = Call(**record["api"]["native_api"])
                     api_calls.append(call)
 
         process = Process(

--- a/capa/loader.py
+++ b/capa/loader.py
@@ -356,7 +356,7 @@ def get_extractor(
     
     elif backend == BACKEND_FRIDA:
         import capa.features.extractors.frida.extractor
-        return capa.features.extractors.frida.extractor.FridaExtractor.from_json_file(input_path)
+        return capa.features.extractors.frida.extractor.FridaExtractor.from_jsonl_file(input_path)
    
     else:
         raise ValueError("unexpected backend: " + backend)
@@ -432,7 +432,7 @@ def get_file_extractors(input_file: Path, input_format: str) -> list[FeatureExtr
     elif input_format == FORMAT_FRIDA:
         import capa.features.extractors.frida.extractor
         
-        file_extractors.append(capa.features.extractors.frida.extractor.FridaExtractor.from_json_file(input_file))
+        file_extractors.append(capa.features.extractors.frida.extractor.FridaExtractor.from_jsonl_file(input_file))
 
     return file_extractors
 

--- a/scripts/frida/README.md
+++ b/scripts/frida/README.md
@@ -53,6 +53,7 @@ adb shell su -c "ls -la /data/local/tmp/frida_output/"
 adb shell su -c "cat /data/local/tmp/frida_output/api_calls.jsonl" > api_calls.jsonl
 
 # OR Method 2: Using adb pull
+adb root
 adb pull /data/local/tmp/frida_output/api_calls.jsonl ./frida_reports/api_calls.jsonl
 ```
 

--- a/scripts/frida/frida_api_models.py
+++ b/scripts/frida/frida_api_models.py
@@ -32,30 +32,43 @@ class JavaApi(BaseModel):
         return self
 
 
-class JniApi(BaseModel):
-    pass
-
+SUPPORTED_NATIVE_TYPES = {
+    'int', 'uint', 'bool',
+    'char*', 'const char*'
+}
+UNSUPPORTED_NATIVE_TYPES = {
+    'long', 'ulong', 'size_t', 'float', 'double',
+    'void*', 'pointer'
+}
+VALID_NATIVE_TYPES = SUPPORTED_NATIVE_TYPES.union(UNSUPPORTED_NATIVE_TYPES)
 
 class NativeApi(BaseModel):
-    pass
+    library: str
+    function: str
+    arguments: bool = True
+    argument_types: List[str] = Field(default_factory=list)
+
+    @model_validator(mode='after')
+    def validate_argument_types(self):
+        print(f'Reminder: supported types are {SUPPORTED_NATIVE_TYPES}. '
+          f'If the API argument you added uses one of these types, make sure it is spelled correctly.')
+        for arg_type in self.argument_types:
+            if arg_type not in VALID_NATIVE_TYPES:
+                print(f'Reminder: {arg_type}. Please double-check for typos.')
+        return self
 
 
-class JavaSection(BaseModel):
+class JavaApis(BaseModel):
     methods: List[JavaApi] = Field(default_factory=list)
 
 
-class JniSection(BaseModel):
-    methods: List[JniApi] = Field(default_factory=list)
-
-
-class NativeSection(BaseModel):
+class NativeApis(BaseModel):
     methods: List[NativeApi] = Field(default_factory=list)
 
 
 class FridaApiSpec(BaseModel):
     """Main configuration for Frida APIs"""
     java: Optional[JavaSection] = None
-    jni: Optional[JniSection] = None
     native: Optional[NativeSection] = None
     
     @classmethod
@@ -64,4 +77,3 @@ class FridaApiSpec(BaseModel):
         with open(json_path, 'r') as f:
             data = json.load(f)
         return cls(**data)
-

--- a/scripts/frida/hook_builder.py
+++ b/scripts/frida/hook_builder.py
@@ -98,10 +98,6 @@ def main(argv=None):
 
     logging.basicConfig(level=logging.INFO)
 
-    apis_file = Path(args.apis_file_path)
-    template_dir = Path(args.templates_dir)
-    output_dir = Path(args.output_dir)
-
     if not apis_file.exists():
         raise FileNotFoundError(f"APIs file not found: {apis_file}")
     

--- a/scripts/frida/hook_builder.py
+++ b/scripts/frida/hook_builder.py
@@ -54,13 +54,30 @@ def generate_java_hooks_file(java_apis, template_dir, output_file_path):
 
     print(f"Successfully generated Java hooks to {output_file_path}")
 
-def generate_jni_hooks_file(jni_apis, template_dir, output_file_path):
-    # TODO: generate_jni_hooks
-    pass
+def generate_native_hook(template, native_info):
+    var_name = native_info.library.replace('.', '_').replace('-', '_')
+    return template.render(
+        LIBRARY_NAME=native_info.library,
+        VAR_NAME=var_name,
+        FUNCTION_NAME=native_info.function,
+        capture_args=native_info.arguments,
+        argument_types=native_info.argument_types
+    )
 
 def generate_native_hooks_file(native_apis, template_dir, output_file_path):
-    # TODO: generate_native_hooks
-    pass
+    all_native_hooks = []
+    native_template = load_template(template_dir, "native_method.template")
+    
+    for i, native_info in enumerate(native_apis.methods):
+        hook = generate_native_hook(native_template, native_info)
+        all_native_hooks.append(hook)
+    
+    # Write to output file
+    with open(output_file_path, 'w') as f:
+        f.write("\n\n".join(all_native_hooks))
+    
+    print(f"Successfully generated Native hooks to {output_file_path}")
+
 
 def generate_complete_frida_script(template_dir, output_file_path):
     # TODO: Will implement after every hooks are finalized
@@ -100,15 +117,10 @@ def main(argv=None):
         java_output_file_path = output_dir / "java_hooks.js"
         generate_java_hooks_file(frida_apis.java, template_dir, java_output_file_path)
     
-    # JNI hooks
-    if frida_apis.jni and frida_apis.jni.methods:
-        jni_output = output_dir / "jni_hooks.js"
-        generate_java_hooks_file(frida_apis.jni, template_dir, jni_output)
-
     # Native hooks
     if frida_apis.native and frida_apis.native.methods:
         native_output = output_dir / "native_hooks.js"
-        generate_java_hooks_file(frida_apis.native, template_dir, native_output)
+        generate_native_hooks_file(frida_apis.native, template_dir, native_output)
     
     return 0
     

--- a/scripts/frida/hook_templates/java_constructor.template
+++ b/scripts/frida/hook_templates/java_constructor.template
@@ -11,7 +11,7 @@ try {
                 });
             }
             {% endif %}
-            recordApiCall('{{CLASS_NAME}}.<init>', args);
+            recordApiCall('{{CLASS_NAME}}.<init>', args, "java_api");
             return this.$init.apply(this, arguments);
         };
     });

--- a/scripts/frida/hook_templates/java_method.template
+++ b/scripts/frida/hook_templates/java_method.template
@@ -16,7 +16,7 @@ try {
             {% else %}
             var result = this.{{METHOD_NAME}}.apply(this, arguments);
             {% endif %}
-            recordApiCall('{{CLASS_NAME}}.{{METHOD_NAME}}', args);
+            recordApiCall('{{CLASS_NAME}}.{{METHOD_NAME}}', args, "java_api");
             return result;
         };
     });

--- a/scripts/frida/hook_templates/native_method.template
+++ b/scripts/frida/hook_templates/native_method.template
@@ -1,0 +1,20 @@
+try {
+    var {{VAR_NAME}} = Process.getModuleByName('{{LIBRARY_NAME}}');
+    var {{FUNCTION_NAME}}_addr = {{VAR_NAME}}.getExportByName('{{FUNCTION_NAME}}');
+    Interceptor.attach({{FUNCTION_NAME}}_addr, {
+        onEnter: function(args) {
+            var arguments_list = [];
+            {% if capture_args %}
+            {% for arg_type in argument_types %}
+            arguments_list.push({
+                name: 'arg{{loop.index0}}',
+                value: parseNativeValue(args[{{loop.index0}}], '{{arg_type}}')
+            });
+            {% endfor %}
+            {% endif %}
+            recordApiCall('{{LIBRARY_NAME}}.{{FUNCTION_NAME}}', arguments_list, "native_api");
+        }
+    });
+} catch (e) {
+    console.log('[ERROR] Failed to hook native function {{LIBRARY_NAME}}.{{FUNCTION_NAME}}: ' + e.message);
+}


### PR DESCRIPTION
Done: 
1. Add native API hooking support with native_method.template.
2. Update native API JSON structure as:
```
{
    "native": {
        "methods": [
            {
                "library": "libc.so",
                "function": "open",
                "arguments": true,
                "argument_types": ["char*", "int"]
            }
        ]
    }
}
```
3. Support 'int', 'uint', 'bool', 'char*', 'const char*' argument parsing.

TODO:
1. A complete template to generate script.
2. There are many issues that need testing. The main problems seem to be with loadLibrary(), such as, its hooking location appears to affect different results, etc. Still thinking.